### PR TITLE
Modify: fix tooltipTry and tooltipLazy's valuation bug

### DIFF
--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -33,10 +33,10 @@
           , originSide = attr.tooltipSide || 'top'
           , side = originSide
           , size = attr.tooltipSize || 'medium'
-          , tryPosition = $scope.$eval(attr.tooltipTry) || true
+          , tryPosition = typeof attr.tooltipTry !== 'undefined' && attr.tooltipTry !== null ? $scope.$eval(attr.tooltipTry) : true
           , className = attr.tooltipClass || ''
           , speed = (attr.tooltipSpeed || 'medium').toLowerCase()
-          , lazyMode = $scope.$eval(attr.tooltipLazy) || true
+          , lazyMode = typeof attr.tooltipLazy !== 'undefined' && attr.tooltipLazy !== null $scope.$eval(attr.tooltipLazy) : true
           , htmlTemplate =
               '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">' +
               '<div class="' + CSS_PREFIX + 'title"> ' + title + '</div>' +


### PR DESCRIPTION
Hi, @45kb 
Sorry about the wrong usage of “||” when evaluate lazyMode. 
And, the same with tryPosition.