### PR TITLE
hide the tooltip when the directive is destroyed

### DIFF
--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -259,6 +259,9 @@
               }
         };
 
+        //make sure that the tooltip is hidden when the directive is destroyed
+        $scope.$on('$destroy', $scope.hideTooltip);
+
         angular.element($window).bind('resize', function onResize() {
 
           $scope.hideTooltip();


### PR DESCRIPTION
Hello,

I ran into a bug when using this directive on a delete button in my app. Clicking the delete button would remove the parent item from a list. While the element would disappear, the tooltip would remain since the user could not 'mouseleave' from the removed element.  This PR fixes this issue by ensuring that the tooltip is hidden when the directive is destoryed.

Thanks,
Simon