### PR TITLE
Add optional close button

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,12 @@ You can set your tooltip to show/hide on specific event/events, you can use the 
 <a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click</a>
 ```
 
+If you want to hide on click, you can configure a close button using text or HTML. This allows your users to click the button inside the tooltip instead of clicking on the original trigger.
+```html
+<a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" close-button="x" tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click, with option to click on the X</a>
+<a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" close-button='<button type="button">Close Me!</button>' tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click, with option to click on HTML button</a>
+```
+
 ####Tooltip CSS class
 You can set a custom CSS class or a set of, using the  `tooltip-class=""` attribute:
 ```html

--- a/Readme.md
+++ b/Readme.md
@@ -154,8 +154,8 @@ You can set your tooltip to show/hide on specific event/events, you can use the 
 
 If you want to hide on click, you can configure a close button using text or HTML. This allows your users to click the button inside the tooltip instead of clicking on the original trigger.
 ```html
-<a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" close-button="x" tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click, with option to click on the X</a>
-<a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" close-button='<button type="button">Close Me!</button>' tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click, with option to click on HTML button</a>
+<a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" tooltip-close-button="x" tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click, with option to click on the X</a>
+<a href="#" tooltips tooltip-title="tip" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" tooltip-close-button='<button type="button">Close Me!</button>' tooltip-side="left">Show tooltip on click and mouseover and hide tooltip only on click, with option to click on HTML button</a>
 ```
 
 ####Tooltip CSS class

--- a/index.html
+++ b/index.html
@@ -90,6 +90,21 @@
     </a>
   </div>
   <div class="separator100"></div>
+
+  <div class="separator30"></div>
+  <div>
+    <a class="btn btn-medium bg-info color-white font-bold" tooltips tooltip-content="Yeo man!" tooltip-show-trigger="mouseover click" tooltip-hide-trigger="click" tooltip-close-button='<button type="button">Close Me!</button>' tooltip-side="top">
+      Close button: hover to open, click to close
+    </a>
+  </div>
+
+  <div class="separator30"></div>
+  <div>
+    <a class="btn btn-medium bg-info color-white font-bold" tooltips tooltip-content="Yeo man! I have some more to say to show the positioning of the close button" tooltip-show-trigger="click" tooltip-hide-trigger="click" tooltip-close-button='<button type="button">Close Me!</button>' tooltip-side="bottom">
+      Close button: click to open and close
+    </a>
+  </div>
+  <div class="separator100"></div>
 </div>
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.4/angular.min.js"></script>
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.4/angular-route.min.js"></script>

--- a/src/css/angular-tooltips.css
+++ b/src/css/angular-tooltips.css
@@ -119,3 +119,6 @@
   border-left-color: transparent;
   border-top-width: 0;
 }
+._720kb-tooltip-close-button {
+  float: right;
+}

--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -42,7 +42,7 @@
           , htmlTemplate = '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">';
 
         if (hasCloseButton) {
-          htmlTemplate = htmlTemplate + '<span ng-click="hideTooltip()"> ' + closeButtonContent + ' </span>'
+          htmlTemplate = htmlTemplate + '<span class="' + CSS_PREFIX + 'close-button" ng-click="hideTooltip()"> ' + closeButtonContent + ' </span>';
         }
 
         htmlTemplate = htmlTemplate + '<div class="' + CSS_PREFIX + 'title"> ' + title + '</div>' +

--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -37,11 +37,17 @@
           , className = attr.tooltipClass || ''
           , speed = (attr.tooltipSpeed || 'medium').toLowerCase()
           , lazyMode = typeof attr.tooltipLazy !== 'undefined' && attr.tooltipLazy !== null ? $scope.$eval(attr.tooltipLazy) : true
-          , htmlTemplate =
-              '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">' +
-              '<div class="' + CSS_PREFIX + 'title"> ' + title + '</div>' +
-              content + ' <span class="' + CSS_PREFIX + 'caret"></span>' +
-              '</div>';
+          , hasCloseButton = typeof attr.closeButton !== 'undefined' && attr.closeButton !== null
+          , closeButtonText = attr.closeButton || ''
+          , htmlTemplate = '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">';
+
+        if (hasCloseButton) {
+          htmlTemplate = htmlTemplate + '<span ng-click="hideTooltip()"> ' + closeButtonText + ' </span>'
+        }
+
+        htmlTemplate = htmlTemplate + '<div class="' + CSS_PREFIX + 'title"> ' + title + '</div>' +
+                                      content + ' <span class="' + CSS_PREFIX + 'caret"></span>' +
+                                      '</div>';
 
         //parse the animation speed of tooltips
         $scope.parseSpeed = function parseSpeed () {

--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -37,8 +37,8 @@
           , className = attr.tooltipClass || ''
           , speed = (attr.tooltipSpeed || 'medium').toLowerCase()
           , lazyMode = typeof attr.tooltipLazy !== 'undefined' && attr.tooltipLazy !== null ? $scope.$eval(attr.tooltipLazy) : true
-          , hasCloseButton = typeof attr.closeButton !== 'undefined' && attr.closeButton !== null
-          , closeButtonText = attr.closeButton || ''
+          , hasCloseButton = typeof attr.tooltipCloseButton !== 'undefined' && attr.tooltipCloseButton !== null
+          , closeButtonText = attr.tooltipCloseButton || ''
           , htmlTemplate = '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">';
 
         if (hasCloseButton) {

--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -38,11 +38,11 @@
           , speed = (attr.tooltipSpeed || 'medium').toLowerCase()
           , lazyMode = typeof attr.tooltipLazy !== 'undefined' && attr.tooltipLazy !== null ? $scope.$eval(attr.tooltipLazy) : true
           , hasCloseButton = typeof attr.tooltipCloseButton !== 'undefined' && attr.tooltipCloseButton !== null
-          , closeButtonText = attr.tooltipCloseButton || ''
+          , closeButtonContent = attr.tooltipCloseButton || ''
           , htmlTemplate = '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">';
 
         if (hasCloseButton) {
-          htmlTemplate = htmlTemplate + '<span ng-click="hideTooltip()"> ' + closeButtonText + ' </span>'
+          htmlTemplate = htmlTemplate + '<span ng-click="hideTooltip()"> ' + closeButtonContent + ' </span>'
         }
 
         htmlTemplate = htmlTemplate + '<div class="' + CSS_PREFIX + 'title"> ' + title + '</div>' +


### PR DESCRIPTION
We wanted to have tooltips be click to close (to accommodate clicking links inside) and found our users (really other devs roped into testing) had trouble finding how to close the tooltip. They first clicked outside the tooltip or inside the tooltip. Only after did they clicked on the original span they moused over/clicked on.

We wanted to add a close icon to provide a clear indication about where to click.

The resulting code to build up the template is little ugly, and this might be an edge use case, so no worries if this isn't something you're looking for.

Let me know if you'd like any changes or if I missed some documentation.

Thanks!