### PR TITLE
Make tooltip offsets relative to the viewport

### DIFF
--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -100,24 +100,12 @@
           }
         };
 
-        $scope.getRootOffsetTop = function getRootOffsetTop (elem, val){
-
-          if (elem.offsetParent === null){
-
-            return val + elem.offsetTop;
-          }
-
-          return $scope.getRootOffsetTop(elem.offsetParent, val + elem.offsetTop);
+        $scope.getRootOffsetTop = function getRootOffsetTop (elem){
+          return elem.getBoundingClientRect().top;
         };
 
-        $scope.getRootOffsetLeft = function getRootOffsetLeft (elem, val){
-
-          if (elem.offsetParent === null){
-
-            return val + elem.offsetLeft;
-          }
-
-          return $scope.getRootOffsetLeft(elem.offsetParent, val + elem.offsetLeft);
+        $scope.getRootOffsetLeft = function getRootOffsetLeft (elem){
+          return elem.getBoundingClientRect().left;
         };
 
         $scope.bindShowTriggers = function() {


### PR DESCRIPTION
Uses `getBoundingClientRect()` to calculate left and top offsets
Fix for https://github.com/720kb/angular-tooltips/issues/25