### PR TITLE
Add fade-out transition

### DIFF
--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -196,8 +196,8 @@
         };
 
         $scope.hideTooltip = function hideTooltip () {
+          theTooltip.css('transition', 'opacity ' + speed + 'ms linear, visibility 0s linear ' + speed + 'ms');
           theTooltip.removeClass(CSS_PREFIX + 'open');
-          theTooltip.css('transition', '');
           $scope.clearTriggers();
           $scope.bindShowTriggers();
 


### PR DESCRIPTION
Tooltips are now fading out with the same transition (concerning speed &
easing) as they are fading in.

Possible future enhancements:
- Different speeds for fade-in / fade-out
- Transition easing as directive attribute (e.g. tooltip-transition="ease")