### PR TITLE
(hot-fix) disable pointer-events on tooltips

### DIFF
--- a/src/css/angular-tooltips.css
+++ b/src/css/angular-tooltips.css
@@ -11,6 +11,7 @@ visibility:hidden;
   border-radius:3px;
   left:-200%;
   top: 0;
+  pointer-events:none;
 }
 ._720kb-tooltip-title{
   color:rgba(255,255,255,0.95);


### PR DESCRIPTION
Solves button/link hover issue in IE 11.