### PR TITLE
add 'both' hideTarget, keeping tooltip open if mouse is over element OR tooltip

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -186,8 +186,8 @@ If you want to hide on click, you can configure a close button using text or HTM
 ```
 
 ####Tooltip hide trigger target
-You can use ```tooltip-hide-target=""``` to specify if the target of the ```tooltip-hide-trigger=""``` is the element or the tooltip itself.
-Values are "element" or "tooltip". Default: `element`
+You can use ```tooltip-hide-target=""``` to specify if the target of the ```tooltip-hide-trigger=""``` is the element, the tooltip itself, or both. If both is selected, the tooltip will remain visible if user's mouse is over the tooltip or the element. This is useful for keeping the element visible if it contains interactive components (like links).
+Values are "element", "tooltip", or "both". Default: `element`
 
 ```html
 <a href="#" tooltips tooltip-title="tooltip" tooltip-hide-trigger="click" tooltip-hide-target="tooltip">

--- a/src/css/angular-tooltips.css
+++ b/src/css/angular-tooltips.css
@@ -13,6 +13,9 @@ visibility:hidden;
   top: 0;
   pointer-events:none;
 }
+._720kb-tooltip.interactive {
+  pointer-events: auto;
+}
 ._720kb-tooltip-title{
   color:rgba(255,255,255,0.95);
   font-weight: 500;

--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -40,7 +40,8 @@
       , POSITION_CHECK_INTERVAL = 20 // ms
       , CSS_PREFIX = '_720kb-tooltip-'
       , INTERPOLATE_START_SYM = $interpolate.startSymbol()
-      , INTERPOLATE_END_SYM = $interpolate.endSymbol();
+      , INTERPOLATE_END_SYM = $interpolate.endSymbol()
+      , DELAYED_MOUSEOUT_TIME = 250; // ms
 
      return {
       'restrict': 'A',
@@ -79,7 +80,7 @@
           , hasCloseButton = typeof closeButtonContent !== 'undefined' && closeButtonContent !== null
           , htmlTemplate = '<div class="_720kb-tooltip ' + CSS_PREFIX + size + '">';
 
-        if (hideTarget !== 'element' && hideTarget !== 'tooltip') {
+        if (hideTarget !== 'element' && hideTarget !== 'tooltip' && hideTarget !== 'both') {
 
           hideTarget = 'element';
         }
@@ -201,6 +202,24 @@
           $scope.hideTooltip();
         }
 
+        $scope.mouseoverTooltip = false;
+        $scope.mouseoverElement = false;
+
+        function shouldHide() {
+            return !$scope.mouseoverElement && !$scope.mouseoverTooltip;
+        }
+
+        function delayedMouseLeaveAndMouseOut() {
+            // wait a tick before hiding stuff because
+            // user intention is not yet clear
+            setTimeout(function(){
+                if(shouldHide()){
+
+                    onMouseLeaveAndMouseOut();
+                }
+            }, DELAYED_MOUSEOUT_TIME);
+        }
+
         $scope.bindShowTriggers = function bindShowTriggerHandle() {
           thisElement.bind(showTriggers, onMouseEnterAndMouseOver);
         };
@@ -209,10 +228,28 @@
           if (hideTarget === 'tooltip'){
 
             theTooltip.bind(hideTriggers, onMouseLeaveAndMouseOut);
-          } else {
+          } else if(hideTarget === 'element'){
 
             thisElement.bind(hideTriggers, onMouseLeaveAndMouseOut);
-          }
+          } else if(hideTarget === 'both'){
+
+            // keep track of mouseover tooltip
+            theTooltip.hover(function(){
+              $scope.mouseoverTooltip = true;
+            }, function(){
+              $scope.mouseoverTooltip = false;
+            });
+
+            // keep track of mouseover element
+            thisElement.hover(function(){
+              $scope.mouseoverElement = true;
+            }, function(){
+              $scope.mouseoverElement = false;
+            });
+
+            theTooltip.bind(hideTriggers, delayedMouseLeaveAndMouseOut);
+            thisElement.bind(hideTriggers, delayedMouseLeaveAndMouseOut);
+           }
         };
 
         $scope.clearTriggers = function clearTriggersHandle() {
@@ -238,6 +275,7 @@
           }
 
           theTooltip.addClass(CSS_PREFIX + 'open');
+          theTooltip.addClass("interactive");
           theTooltip.css('transition', 'opacity ' + speed + 'ms linear');
 
           if (delay) {
@@ -253,6 +291,7 @@
 
           theTooltip.css('transition', 'opacity ' + speed + 'ms linear, visibility 0s linear ' + speed + 'ms');
           theTooltip.removeClass(CSS_PREFIX + 'open');
+          theTooltip.removeClass("interactive");
           $scope.clearTriggers();
           $scope.bindShowTriggers();
 


### PR DESCRIPTION
The "tooltip" hideTarget causes the tooltip the remain open until the user mouses on then off of it, which probably isn't the best behavior. This PR adds the "both" hideTarget, which keeps track if user mouse is currently over the element OR the tooltip. If it is over neither, it hides the tooltip.  

Since it takes a short time for the user's mouse to travel from the element to the tooltip, there is a new constant value defining the amount of time to wait before checking if the tooltip should be hidden. This may be useful as a user configurable value.  

Finally, pointer-events are toggled on and off depending on the tooltip's visibility.

I believe this PR would close https://github.com/720kb/angular-tooltips/issues/76