### PR TITLE
Quotes fix in the example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -221,7 +221,7 @@ angular
   .config(function(tooltipsConfigProvider) {
     tooltipsConfigProvider.options({
       lazy: false,
-      size: large
+      size: 'large'
     })
   });
 ```


### PR DESCRIPTION
Example were missing quotes around the string ‘large’