### PR TITLE
Ensure tooltips are actually hidden when not open

### DIFF
--- a/src/css/angular-tooltips.css
+++ b/src/css/angular-tooltips.css
@@ -8,8 +8,10 @@
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
-  left: -200%;
   top: 0;
+}
+._720kb-tooltip:not(._720kb-tooltip-open) {
+  visibility: hidden !important;
 }
 
 ._720kb-tooltip-title {


### PR DESCRIPTION
Forcing `hidden` visibility on `:not`-open elements doesn't seem to impact the animation of the opacity, but it does ensure that the visibility will be `hidden` when the tooltip is not open: in my testing on Safari, Firefox and Chrome, this resolves the issue where hidden tooltips prevent interaction with items occluded by the tooltip element.

Closes #95