### PR TITLE
Issue #103 fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -234,6 +234,20 @@ I will follow my element movements
 </a>
 ```
 
+
+####Tooltip DOM parent
+By default, the tooltip DOM container is BODY. Given a DIV that is displayed/hidden dynamically and one wants to create tooltips inside that DIV, one needs to register the corresponding DIV container using `tooltip-parent="<container id>"`.
+```html
+<body>
+<div id="abc"> ... </div>
+<div id="def">
+   <a href="#" tooltips tooltip-title="I want to appear!" tooltip-parent="def">Example link with tooltip</a>
+</div>
+</body>
+```
+
+
+
 ## Global Options
 Application wide defaults for most of the options can be set using the `tooltipConfigProvider`:
 

--- a/src/js/angular-tooltips.js
+++ b/src/js/angular-tooltips.js
@@ -50,7 +50,7 @@
 
         var initialized = false
           , thisElement = angular.element(element[0])
-          , body = angular.element($window.document.getElementsByTagName('body')[0])
+          , domParent = ($window.document.getElementById(attr.tooltipParent) ? angular.element($window.document.getElementById(attr.tooltipParent)) : null) || angular.element($window.document.getElementsByTagName('body')[0])
           , theTooltip
           , theTooltipHeight
           , theTooltipWidth
@@ -135,7 +135,7 @@
 
         theTooltip.addClass(className);
 
-        body.append(theTooltip);
+        domParent.append(theTooltip);
 
         $scope.isTooltipEmpty = function checkEmptyTooltip() {
 


### PR DESCRIPTION
In order to fix issue #103 I have added a new directive attribute called "tooltip-parent" that receives the name of the tooltip div parent container. If attribute isn't present (or its value doesn't exist in DOM) then it defaults to past behavior, that is, the tooltip is appended to `<body>`.