### PR TITLE
add template caching

### DIFF
--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -221,7 +221,7 @@
       }
     };
   }
-  , tooltipDirective = /*@ngInject*/ function tooltipDirective($log, $http, $compile, $timeout, $controller, $injector, tooltipsConf) {
+  , tooltipDirective = /*@ngInject*/ function tooltipDirective($log, $http, $compile, $timeout, $controller, $injector, $templateCache, tooltipsConf) {
 
     var linkingFunction = function linkingFunction($scope, $element, $attrs, $controllerDirective, $transcludeFunc) {
 
@@ -550,21 +550,26 @@
             }
           }
           , onTooltipTemplateUrlChange = function onTooltipTemplateUrlChange(newValue) {
-
             if (newValue) {
-
-              $http.get(newValue).then(function onResponse(response) {
-
-                if (response &&
-                  response.data) {
-
+              var applyTemplate = function applyTemplate(template) {
                   tipTipElement.empty();
                   tipTipElement.append(closeButtonElement);
-                  tipTipElement.append($compile(response.data)(scope));
+                  tipTipElement.append($compile(template)(scope));
                   $timeout(function doLater() {
-
                     onTooltipShow();
                   });
+                }
+                , cachedTemplate = $templateCache.get(newValue);
+
+              if (cachedTemplate) {
+                applyTemplate(cachedTemplate);
+                return;
+              }
+
+              $http.get(newValue).then(function onResponse(response) {
+                if (response && response.data) {
+                  cachedTemplate = $templateCache.put(newValue, response.data);
+                  applyTemplate(cachedTemplate);
                 }
               });
             }


### PR DESCRIPTION
When using `tooltip-template-url`, don't refetch template if there's a cache for it.