### PR TITLE
Angular Template cache is now supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea/
 node_modules/
 bower_components/
 npm-debug.log

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -221,7 +221,7 @@
       }
     };
   }
-  , tooltipDirective = /*@ngInject*/ function tooltipDirective($log, $http, $compile, $timeout, $controller, $injector, tooltipsConf) {
+  , tooltipDirective = /*@ngInject*/ function tooltipDirective($log, $http, $compile, $timeout, $controller, $injector, tooltipsConf, $templateCache) {
 
     var linkingFunction = function linkingFunction($scope, $element, $attrs, $controllerDirective, $transcludeFunc) {
 
@@ -549,25 +549,34 @@
               });
             }
           }
-          , onTooltipTemplateUrlChange = function onTooltipTemplateUrlChange(newValue) {
+          , onTooltipTemplateUrlChange = function onTooltipTemplateUrlChange(templateUrl) {
 
-            if (newValue) {
-
-              $http.get(newValue).then(function onResponse(response) {
-
-                if (response &&
-                  response.data) {
-
-                  tipTipElement.empty();
-                  tipTipElement.append(closeButtonElement);
-                  tipTipElement.append($compile(response.data)(scope));
-                  $timeout(function doLater() {
-
-                    onTooltipShow();
-                  });
-                }
-              });
+            if (!templateUrl) {
+              return;
             }
+
+            // Trying to load template from the template cache first.
+            var template = $templateCache.get(templateUrl);
+
+            if ('undefined' === typeof template) {
+              $http
+                .get(templateUrl)
+                .then(function onResponse(response) {
+                  if (response && response.data) {
+                    template = response.data;
+                    $templateCache.put(templateUrl, template);
+                  }
+                })
+              ;
+            }
+
+            tipTipElement.empty();
+            tipTipElement.append(closeButtonElement);
+            tipTipElement.append($compile(template)(scope));
+            $timeout(function doLater() {
+              onTooltipShow();
+            });
+
           }
           , onTooltipSideChange = function onTooltipSideChange(newValue) {
 


### PR DESCRIPTION
I've implemented support for Angular template cache. Now, the module first tries to load specified template from cache and then falls back to `$http.get`. When template is actually loaded from server it is saved in the cache for further use. This is the expected behavior for any Angular module that uses templates.