### PR TITLE
Export dist file instead of source.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 (function commonJS(require, module) {
   'use strict';
 
-  require('./lib/angular-tooltips');
+  require('./dist/angular-tooltips');
 
   module.exports = '720kb.tooltips';
 }(require, module));


### PR DESCRIPTION
I ran into the same issue with #146. It seems because `index.js` was exporting source file which requires to be built first instead of a dist file that are ready use. However, my project doesn't use the same build process as angular-tooltips and I didn't want to have to go through the process of building the dependency packages.

It would be much nicer if angular-tooltips export a dist file that's been built and ready to be used.