### PR TITLE
Fix event listeners/DOM nodes memory leak and throttle resize events

### DIFF
--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -21,9 +21,12 @@
           window.console.log('Skipped!');
         }
       }
+      , resizeTimeout
       , resize = function resize() {
-
-        window.requestAnimationFrame(runCallbacks);
+        window.clearTimeout(resizeTimeout);
+        resizeTimeout = window.setTimeout(function onResizeTimeout() {
+          window.requestAnimationFrame(runCallbacks);
+        }, 500);
       }
       , addCallback = function addCallback(callback) {
 
@@ -41,6 +44,12 @@
           window.addEventListener('resize', resize);
         }
         addCallback(callback);
+      },
+      'remove': function remove() {
+        if (!callbacks.length) {
+          window.clearTimeout(resizeTimeout);
+          window.removeEventListener('resize', resize);
+        }
       }
     };
   }())
@@ -767,6 +776,7 @@
           unregisterOnTooltipSizeChange();
           unregisterOnTooltipSpeedChange();
           unregisterTipContentChangeWatcher();
+          resizeObserver.remove();
           element.off($attrs.tooltipShowTrigger + ' ' + $attrs.tooltipHideTrigger);
         });
       });


### PR DESCRIPTION
Includes:
- Unbind 'resize' event handlers on $destroy (as per issue #143). Not only this
  reduces the overall number of listeners being bound, but also allows DOM
  nodes to be GC'ed.
- To alleviate some CPU churn, we now throttle the resize event handler. By
  doing so, we enable users to resize their browsers in a much smoother
  fashion.

**Timeline Before:**
![timeline before](https://cloud.githubusercontent.com/assets/144857/15294575/a6a727a0-1b41-11e6-91e9-0aee521a32a9.png)
**Timeline After:**
![timeline after](https://cloud.githubusercontent.com/assets/144857/15294576/a6a95ab6-1b41-11e6-8e07-43b44293df92.png)
**Listeners/DOM Nodes/JS Heap Before:**
![listeners before](https://cloud.githubusercontent.com/assets/144857/15294574/a6a7045a-1b41-11e6-9536-eeda8d97a6ab.png)
**Listeners/DOM Nodes/JS Heap After:**
![listeners after](https://cloud.githubusercontent.com/assets/144857/15294577/a6b52300-1b41-11e6-9fe9-08b1e2aa76cc.png)