### PR TITLE
Use !default to declare SCSS variables & make font-sizes configurable

### DIFF
--- a/lib/angular-tooltips.scss
+++ b/lib/angular-tooltips.scss
@@ -8,6 +8,9 @@ $tooltip-border-radius: 3px !default;
 $tooltip-fast-transition: .15s !default;
 $tooltip-slow-transition: .65s !default;
 $tooltip-medium-transition: .35s !default;
+$tooltip-font-size-small: .8em !default;
+$tooltip-font-size-medium: .95em !default;
+$tooltip-font-size-large: 1.1em !default;
 
 @mixin opacity-transition($speed) {
   animation: animate-tooltip $speed;
@@ -144,16 +147,16 @@ tooltip {
 
   tip-tip {
 
-    font-size: .95em;
+    font-size: $tooltip-font-size-medium;
 
     &._large {
 
-      font-size: 1.1em;
+      font-size: $tooltip-font-size-large;
     }
 
     &._small {
 
-      font-size: .8em;
+      font-size: $tooltip-font-size-small;
     }
   }
 

--- a/lib/angular-tooltips.scss
+++ b/lib/angular-tooltips.scss
@@ -1,13 +1,13 @@
-$tolerance: 3px;
-$margin-tooltip-arrow: 6px;
-$padding-top-bottom-tooltip: 8px;
-$padding-right-left-tooltip: 16px;
-$tooltip-background-color: rgba(0, 0, 0, .85);
-$tooltip-color: #fff;
-$tooltip-border-radius: 3px;
-$tooltip-fast-transition: .15s;
-$tooltip-slow-transition: .65s;
-$tooltip-medium-transition: .35s;
+$tolerance: 3px !default;
+$margin-tooltip-arrow: 6px !default;
+$padding-top-bottom-tooltip: 8px !default;
+$padding-right-left-tooltip: 16px !default;
+$tooltip-background-color: rgba(0, 0, 0, .85) !default;
+$tooltip-color: #fff !default;
+$tooltip-border-radius: 3px !default;
+$tooltip-fast-transition: .15s !default;
+$tooltip-slow-transition: .65s !default;
+$tooltip-medium-transition: .35s !default;
 
 @mixin opacity-transition($speed) {
   animation: animate-tooltip $speed;


### PR DESCRIPTION
1. Declare all SCSS vars as !default so that they can be overridden by users wanting different settings
2. Declare font sizes with variables so that they can be configured also

https://github.com/720kb/angular-tooltips/issues/177