### PR TITLE
Ability to specify an element the tooltip should stay in when smart mode is enabled

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,6 +96,7 @@ tooltip-close-button="" | String(Boolean) | false | Enable the tooltip close but
 tooltip-class="" | String() | '' | Set custom tooltip CSS class/classes
 tooltip-size="" | String('large', 'small') | 'medium' | Set your tooltip dimensions
 tooltip-speed="" | String('fast', 'slow', 'medium') | 'medium' | Set your tooltip show & hide transition speed
+tooltip-viewport="" | String('.selector') | '' | Set the viewport for your tooltip to an element other than the body (only when smart is enabled)
 tooltip-hidden="" | String(Boolean) | false | Hide (at all) the tooltip
 tooltip-append-to-body="" | String(Boolean) | false | This attribute clones the tooltip and append this directly on body. This enables the tooltip position also, for instance, if you have an scrolling area. **This option does heavy javascript calculation.**
 

--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,7 @@ tooltip-class="" | String() | '' | Set custom tooltip CSS class/classes
 tooltip-size="" | String('large', 'small') | 'medium' | Set your tooltip dimensions
 tooltip-speed="" | String('fast', 'slow', 'medium') | 'medium' | Set your tooltip show & hide transition speed
 tooltip-viewport="" | String('.selector') | '' | Set the viewport for your tooltip to an element other than the body (only when smart is enabled)
+tooltip-show-on-truncate="" | String(Boolean) | false | Set the tooltip to only show up when the tooltip is wider / taller than it's parent element
 tooltip-hidden="" | String(Boolean) | false | Hide (at all) the tooltip
 tooltip-append-to-body="" | String(Boolean) | false | This attribute clones the tooltip and append this directly on body. This enables the tooltip position also, for instance, if you have an scrolling area. **This option does heavy javascript calculation.**
 

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -129,6 +129,12 @@
       element.removeAttr('tooltip-speed');
     }
 
+    if (element.attr('tooltip-viewport') !== undefined) {
+
+      attributesToAdd['tooltip-viewport'] = element.attr('tooltip-viewport');
+      element.removeAttr('tooltip-viewport');
+    }
+
     return attributesToAdd;
   }
   , getStyle = function getStyle(anElement) {
@@ -170,19 +176,24 @@
       tipElement.remove();
     }
   }
-  , isOutOfPage = function isOutOfPage(theTipElement) {
+  , isOutOfView = function isOutOfView(theTipElement, viewportElement) {
 
     if (theTipElement) {
-      var squarePosition = theTipElement[0].getBoundingClientRect();
+      var squarePosition = theTipElement[0].getBoundingClientRect()
+        , viewportPosition = viewportElement[0].getBoundingClientRect();
 
       if (squarePosition.top < 0 ||
         squarePosition.top > window.document.body.offsetHeight ||
+        squarePosition.top < viewportPosition.top ||
         squarePosition.left < 0 ||
         squarePosition.left > window.document.body.offsetWidth ||
+        squarePosition.left < viewportPosition.left ||
         squarePosition.bottom < 0 ||
         squarePosition.bottom > window.document.body.offsetHeight ||
+        squarePosition.bottom > viewportPosition.bottom ||
         squarePosition.right < 0 ||
-        squarePosition.right > window.document.body.offsetWidth) {
+        squarePosition.right > window.document.body.offsetWidth ||
+        squarePosition.right > viewportPosition.right) {
 
         theTipElement.css({
           'top': '',
@@ -209,7 +220,8 @@
       'closeButton': false,
       'size': '',
       'speed': 'steady',
-      'tooltipTemplateUrlCache': false
+      'tooltipTemplateUrlCache': false,
+      'viewport': ''
     };
 
     return {
@@ -253,6 +265,12 @@
         throw new Error('You can not have a controller without a template or templateUrl defined');
       }
 
+      if ($attrs.tooltipViewport &&
+        !$attrs.tooltipSmart) {
+
+        throw new Error('You can not have a tooltip-viewport without tooltip-smart enabled');
+      }
+
       var oldTooltipSide = '_' + tooltipsConf.side
         , oldTooltipShowTrigger = tooltipsConf.showTrigger
         , oldTooltipHideTrigger = tooltipsConf.hideTrigger
@@ -268,6 +286,7 @@
       $attrs.tooltipCloseButton = $attrs.tooltipCloseButton || tooltipsConf.closeButton.toString();
       $attrs.tooltipSize = $attrs.tooltipSize || tooltipsConf.size;
       $attrs.tooltipSpeed = $attrs.tooltipSpeed || tooltipsConf.speed;
+      $attrs.tooltipViewport = $attrs.tooltipViewport || tooltipsConf.viewport;
       $attrs.tooltipAppendToBody = $attrs.tooltipAppendToBody === 'true';
 
       $transcludeFunc($scope, function onTransclusionDone(element, scope) {
@@ -278,6 +297,9 @@
           , tipTipElement = angular.element(window.document.createElement('tip-tip'))
           , closeButtonElement = angular.element(window.document.createElement('span'))
           , tipArrowElement = angular.element(window.document.createElement('tip-arrow'))
+          , viewportElement = $attrs.tooltipViewport ? 
+                              angular.element(window.document.querySelector($attrs.tooltipViewport)) :
+                              angular.element(window.document.body)
           , whenActivateMultilineCalculation = function whenActivateMultilineCalculation() {
 
             return tipContElement.html();
@@ -301,19 +323,19 @@
               switch ($attrs.tooltipSide) {
                 case 'top': {
 
-                  if (isOutOfPage(tipElement)) {
+                  if (isOutOfView(tipElement, viewportElement)) {
 
                     tooltipElement.removeClass('_top');
                     tooltipElement.addClass('_left');
-                    if (isOutOfPage(tipElement)) {
+                    if (isOutOfView(tipElement, viewportElement)) {
 
                       tooltipElement.removeClass('_left');
                       tooltipElement.addClass('_bottom');
-                      if (isOutOfPage(tipElement)) {
+                      if (isOutOfView(tipElement, viewportElement)) {
 
                         tooltipElement.removeClass('_bottom');
                         tooltipElement.addClass('_right');
-                        if (isOutOfPage(tipElement)) {
+                        if (isOutOfView(tipElement, viewportElement)) {
 
                           tooltipElement.removeClass('_right');
                           tooltipElement.addClass('_top');
@@ -326,19 +348,19 @@
 
                 case 'left': {
 
-                  if (isOutOfPage(tipElement)) {
+                  if (isOutOfView(tipElement, viewportElement)) {
 
                     tooltipElement.removeClass('_left');
                     tooltipElement.addClass('_bottom');
-                    if (isOutOfPage(tipElement)) {
+                    if (isOutOfView(tipElement, viewportElement)) {
 
                       tooltipElement.removeClass('_bottom');
                       tooltipElement.addClass('_right');
-                      if (isOutOfPage(tipElement)) {
+                      if (isOutOfView(tipElement, viewportElement)) {
 
                         tooltipElement.removeClass('_right');
                         tooltipElement.addClass('_top');
-                        if (isOutOfPage(tipElement)) {
+                        if (isOutOfView(tipElement, viewportElement)) {
 
                           tooltipElement.removeClass('_top');
                           tooltipElement.addClass('_left');
@@ -351,19 +373,19 @@
 
                 case 'bottom': {
 
-                  if (isOutOfPage(tipElement)) {
+                  if (isOutOfView(tipElement, viewportElement)) {
 
                     tooltipElement.removeClass('_bottom');
                     tooltipElement.addClass('_left');
-                    if (isOutOfPage(tipElement)) {
+                    if (isOutOfView(tipElement, viewportElement)) {
 
                       tooltipElement.removeClass('_left');
                       tooltipElement.addClass('_top');
-                      if (isOutOfPage(tipElement)) {
+                      if (isOutOfView(tipElement, viewportElement)) {
 
                         tooltipElement.removeClass('_top');
                         tooltipElement.addClass('_right');
-                        if (isOutOfPage(tipElement)) {
+                        if (isOutOfView(tipElement, viewportElement)) {
 
                           tooltipElement.removeClass('_right');
                           tooltipElement.addClass('_bottom');
@@ -376,19 +398,19 @@
 
                 case 'right': {
 
-                  if (isOutOfPage(tipElement)) {
+                  if (isOutOfView(tipElement, viewportElement)) {
 
                     tooltipElement.removeClass('_right');
                     tooltipElement.addClass('_top');
-                    if (isOutOfPage(tipElement)) {
+                    if (isOutOfView(tipElement, viewportElement)) {
 
                       tooltipElement.removeClass('_top');
                       tooltipElement.addClass('_left');
-                      if (isOutOfPage(tipElement)) {
+                      if (isOutOfView(tipElement, viewportElement)) {
 
                         tooltipElement.removeClass('_left');
                         tooltipElement.addClass('_bottom');
-                        if (isOutOfPage(tipElement)) {
+                        if (isOutOfView(tipElement, viewportElement)) {
 
                           tooltipElement.removeClass('_bottom');
                           tooltipElement.addClass('_right');
@@ -732,6 +754,16 @@
               oldSpeed = newValue;
             }
           }
+          , onTooltipViewportChange = function onTooltipViewportChange(newValue) {
+
+            if (newValue) {
+
+              $attrs.tooltipViewport = angular.element(window.document.querySelector($attrs.tooltipViewport));
+            } else {
+
+              $attrs.tooltipViewport = angular.element(window.document.body);
+            }
+          }
           , unregisterOnTooltipTemplateChange = $attrs.$observe('tooltipTemplate', onTooltipTemplateChange)
           , unregisterOnTooltipTemplateUrlChange = $attrs.$observe('tooltipTemplateUrl', onTooltipTemplateUrlChange)
           , unregisterOnTooltipTemplateUrlCacheChange = $attrs.$observe('tooltipTemplateUrlCache', onTooltipTemplateUrlCacheChange)
@@ -744,6 +776,7 @@
           , unregisterOnTooltipControllerChange = $attrs.$observe('tooltipController', onTooltipTemplateControllerChange)
           , unregisterOnTooltipSizeChange = $attrs.$observe('tooltipSize', onTooltipSizeChange)
           , unregisterOnTooltipSpeedChange = $attrs.$observe('tooltipSpeed', onTooltipSpeedChange)
+          , unregisterOnTooltipViewportChange = $attrs.$observe('tooltipViewport', onTooltipViewportChange)
           , unregisterTipContentChangeWatcher = scope.$watch(whenActivateMultilineCalculation, calculateIfMultiLine);
 
         closeButtonElement.attr({
@@ -803,6 +836,7 @@
           unregisterOnTooltipCloseButtonChange();
           unregisterOnTooltipSizeChange();
           unregisterOnTooltipSpeedChange();
+          unregisterOnTooltipViewportChange();
           unregisterTipContentChangeWatcher();
           resizeObserver.remove();
           element.off($attrs.tooltipShowTrigger + ' ' + $attrs.tooltipHideTrigger);

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -135,6 +135,12 @@
       element.removeAttr('tooltip-viewport');
     }
 
+    if (element.attr('tooltip-show-on-truncate') !== undefined) {
+
+      attributesToAdd['tooltip-show-on-truncate'] = element.attr('tooltip-show-on-truncate');
+      element.removeAttr('tooltip-show-on-truncate');
+    }
+
     return attributesToAdd;
   }
   , getStyle = function getStyle(anElement) {
@@ -221,7 +227,8 @@
       'size': '',
       'speed': 'steady',
       'tooltipTemplateUrlCache': false,
-      'viewport': ''
+      'viewport': '',
+      'showOnTruncate': false
     };
 
     return {
@@ -287,6 +294,7 @@
       $attrs.tooltipSize = $attrs.tooltipSize || tooltipsConf.size;
       $attrs.tooltipSpeed = $attrs.tooltipSpeed || tooltipsConf.speed;
       $attrs.tooltipViewport = $attrs.tooltipViewport || tooltipsConf.viewport;
+      $attrs.tooltipShowOnTruncate = $attrs.tooltipShowOnTruncate === 'true' || tooltipsConf.showOnTruncate;
       $attrs.tooltipAppendToBody = $attrs.tooltipAppendToBody === 'true';
 
       $transcludeFunc($scope, function onTransclusionDone(element, scope) {
@@ -315,7 +323,38 @@
               tooltipElement.removeClass('_multiline');
             }
           }
+          , isTruncated = function isTruncated() {
+            var side,
+                tooltipElementParentStyle = window.getComputedStyle(tooltipElement[0].parentNode),
+                parentPadding = {
+                  'top': tooltipElementParentStyle.getPropertyValue('padding-top'),
+                  'right': tooltipElementParentStyle.getPropertyValue('padding-right'),
+                  'bottom': tooltipElementParentStyle.getPropertyValue('padding-bottom'),
+                  'left': tooltipElementParentStyle.getPropertyValue('padding-left')
+                };
+
+            for (side in parentPadding) {
+
+              if (parentPadding.hasOwnProperty(side)) {
+
+                parentPadding[side] = parseInt(parentPadding[side].substring(0, parentPadding[side].indexOf('px')), 10);
+                parentPadding[side] = isNaN(parentPadding[side]) ? 0 : parentPadding[side];
+              }
+            }
+
+            if (tooltipElement[0].clientWidth < tooltipElement[0].parentNode.clientWidth - parentPadding.left - parentPadding.right &&
+                tooltipElement[0].clientHeight < tooltipElement[0].parentNode.clientHeight - parentPadding.top - parentPadding.bottom) {
+
+              return false;
+            }
+            return true;
+          }
           , onTooltipShow = function onTooltipShow(event) {
+
+            if ($attrs.tooltipShowOnTruncate && !isTruncated()) {
+
+              return;
+            }
 
             tipElement.addClass('_hidden');
             if ($attrs.tooltipSmart) {
@@ -764,6 +803,13 @@
               $attrs.tooltipViewport = angular.element(window.document.body);
             }
           }
+          , onTooltipShowOnTruncateChange = function onTooltipShowOnTruncateChange() {
+
+            if (typeof $attrs.tooltipShowOnTruncate !== 'boolean') {
+
+              $attrs.tooltipShowOnTruncate = $attrs.tooltipShowOnTruncate === 'true';
+            }
+          }
           , unregisterOnTooltipTemplateChange = $attrs.$observe('tooltipTemplate', onTooltipTemplateChange)
           , unregisterOnTooltipTemplateUrlChange = $attrs.$observe('tooltipTemplateUrl', onTooltipTemplateUrlChange)
           , unregisterOnTooltipTemplateUrlCacheChange = $attrs.$observe('tooltipTemplateUrlCache', onTooltipTemplateUrlCacheChange)
@@ -777,6 +823,7 @@
           , unregisterOnTooltipSizeChange = $attrs.$observe('tooltipSize', onTooltipSizeChange)
           , unregisterOnTooltipSpeedChange = $attrs.$observe('tooltipSpeed', onTooltipSpeedChange)
           , unregisterOnTooltipViewportChange = $attrs.$observe('tooltipViewport', onTooltipViewportChange)
+          , unregisterOnTooltipShowOnTruncateChange = $attrs.$observe('tooltipShowOnTruncate', onTooltipShowOnTruncateChange)
           , unregisterTipContentChangeWatcher = scope.$watch(whenActivateMultilineCalculation, calculateIfMultiLine);
 
         closeButtonElement.attr({
@@ -837,6 +884,7 @@
           unregisterOnTooltipSizeChange();
           unregisterOnTooltipSpeedChange();
           unregisterOnTooltipViewportChange();
+          unregisterOnTooltipShowOnTruncateChange();
           unregisterTipContentChangeWatcher();
           resizeObserver.remove();
           element.off($attrs.tooltipShowTrigger + ' ' + $attrs.tooltipHideTrigger);


### PR DESCRIPTION
Currently smart mode is only checking tooltip boundaries compared to the body. It should be user specifiable, so the tooltip can be contained in any element on the page.
