### PR TITLE
[New Attribute] tooltip-show-tooltip

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,7 @@ tooltip-size="" | String('large', 'small') | 'medium' | Set your tooltip dimensi
 tooltip-speed="" | String('fast', 'slow', 'medium') | 'medium' | Set your tooltip show & hide transition speed
 tooltip-hidden="" | String(Boolean) | false | Hide (at all) the tooltip
 tooltip-append-to-body="" | String(Boolean) | false | This attribute clones the tooltip and append this directly on body. This enables the tooltip position also, for instance, if you have an scrolling area. **This option does heavy javascript calculation.**
+tooltip-show-tooltip="" | String(Boolean) | false | Show/Hide the tooltip "manually"
 
 
 ## Globals

--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,7 @@ tooltip-size="" | String('large', 'small') | 'medium' | Set your tooltip dimensi
 tooltip-speed="" | String('fast', 'slow', 'medium') | 'medium' | Set your tooltip show & hide transition speed
 tooltip-hidden="" | String(Boolean) | false | Hide (at all) the tooltip
 tooltip-append-to-body="" | String(Boolean) | false | This attribute clones the tooltip and append this directly on body. This enables the tooltip position also, for instance, if you have an scrolling area. **This option does heavy javascript calculation.**
-tooltip-show-tooltip="" | String(Boolean) | false | Show/Hide the tooltip "manually"
+tooltip-show="" | String(Boolean) | false | Show/Hide the tooltip "manually"
 
 
 ## Globals

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -269,7 +269,7 @@
       $attrs.tooltipSide = $attrs.tooltipSide || tooltipsConf.side;
       $attrs.tooltipShowTrigger = $attrs.tooltipShowTrigger || tooltipsConf.showTrigger;
       $attrs.tooltipHideTrigger = $attrs.tooltipHideTrigger || tooltipsConf.hideTrigger;
-      $attrs.tooltipShowTooltip = $attrs.tooltipShowTooltip || tooltipsConf.showTooltip;
+      $attrs.tooltipShow = $attrs.tooltipShow || tooltipsConf.showTooltip;
       $attrs.tooltipClass = $attrs.tooltipClass || tooltipsConf.class;
       $attrs.tooltipSmart = $attrs.tooltipSmart === 'true' || tooltipsConf.smart;
       $attrs.tooltipCloseButton = $attrs.tooltipCloseButton || tooltipsConf.closeButton.toString();
@@ -754,7 +754,7 @@
           , unregisterOnTooltipSideChangeObserver = $attrs.$observe('tooltipSide', onTooltipSideChange)
           , unregisterOnTooltipShowTrigger = $attrs.$observe('tooltipShowTrigger', onTooltipShowTrigger)
           , unregisterOnTooltipHideTrigger = $attrs.$observe('tooltipHideTrigger', onTooltipHideTrigger)
-          , unregisterOnTooltipShowTooltip = $attrs.$observe('tooltipShowTooltip', onTooltipShowTooltip)
+          , unregisterOnTooltipShowTooltip = $attrs.$observe('tooltipShow', onTooltipShowTooltip)
           , unregisterOnTooltipClassChange = $attrs.$observe('tooltipClass', onTooltipClassChange)
           , unregisterOnTooltipSmartChange = $attrs.$observe('tooltipSmart', onTooltipSmartChange)
           , unregisterOnTooltipCloseButtonChange = $attrs.$observe('tooltipCloseButton', onTooltipCloseButtonChange)

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -215,7 +215,7 @@
       'size': '',
       'speed': 'steady',
       'tooltipTemplateUrlCache': false,
-      'tooltipShowTooltip': null
+      'show': null
     };
 
     return {
@@ -269,7 +269,7 @@
       $attrs.tooltipSide = $attrs.tooltipSide || tooltipsConf.side;
       $attrs.tooltipShowTrigger = $attrs.tooltipShowTrigger || tooltipsConf.showTrigger;
       $attrs.tooltipHideTrigger = $attrs.tooltipHideTrigger || tooltipsConf.hideTrigger;
-      $attrs.tooltipShow = $attrs.tooltipShow || tooltipsConf.showTooltip;
+      $attrs.tooltipShow = $attrs.tooltipShow || tooltipsConf.show;
       $attrs.tooltipClass = $attrs.tooltipClass || tooltipsConf.class;
       $attrs.tooltipSmart = $attrs.tooltipSmart === 'true' || tooltipsConf.smart;
       $attrs.tooltipCloseButton = $attrs.tooltipCloseButton || tooltipsConf.closeButton.toString();

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -111,9 +111,10 @@
       element.removeAttr('tooltip-class');
     }
 
-    if (element.attr('tooltip-show-tooltip') !== undefined) {
-      attributesToAdd['tooltip-show-tooltip'] = element.attr('tooltip-show-tooltip');
-      element.removeAttr('tooltip-show-tooltip');
+    if (element.attr('tooltip-show') !== undefined) {
+
+      attributesToAdd['tooltip-show'] = element.attr('tooltip-show');
+      element.removeAttr('tooltip-show');
     }
 
     if (element.attr('tooltip-close-button') !== undefined) {

--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -111,6 +111,11 @@
       element.removeAttr('tooltip-class');
     }
 
+    if (element.attr('tooltip-show-tooltip') !== undefined) {
+      attributesToAdd['tooltip-show-tooltip'] = element.attr('tooltip-show-tooltip');
+      element.removeAttr('tooltip-show-tooltip');
+    }
+
     if (element.attr('tooltip-close-button') !== undefined) {
 
       attributesToAdd['tooltip-close-button'] = element.attr('tooltip-close-button');
@@ -209,7 +214,8 @@
       'closeButton': false,
       'size': '',
       'speed': 'steady',
-      'tooltipTemplateUrlCache': false
+      'tooltipTemplateUrlCache': false,
+      'tooltipShowTooltip': null
     };
 
     return {
@@ -263,6 +269,7 @@
       $attrs.tooltipSide = $attrs.tooltipSide || tooltipsConf.side;
       $attrs.tooltipShowTrigger = $attrs.tooltipShowTrigger || tooltipsConf.showTrigger;
       $attrs.tooltipHideTrigger = $attrs.tooltipHideTrigger || tooltipsConf.hideTrigger;
+      $attrs.tooltipShowTooltip = $attrs.tooltipShowTooltip || tooltipsConf.showTooltip;
       $attrs.tooltipClass = $attrs.tooltipClass || tooltipsConf.class;
       $attrs.tooltipSmart = $attrs.tooltipSmart === 'true' || tooltipsConf.smart;
       $attrs.tooltipCloseButton = $attrs.tooltipCloseButton || tooltipsConf.closeButton.toString();
@@ -650,6 +657,15 @@
               oldTooltipHideTrigger = newValue;
             }
           }
+          , onTooltipShowTooltip = function onTooltipShowTooltip(newValue) {
+
+            if (newValue === 'true') {
+
+              tooltipElement.addClass('active');
+            } else {
+              tooltipElement.removeClass('active');
+            }
+          }
           , onTooltipClassChange = function onTooltipClassChange(newValue) {
 
             if (newValue) {
@@ -738,6 +754,7 @@
           , unregisterOnTooltipSideChangeObserver = $attrs.$observe('tooltipSide', onTooltipSideChange)
           , unregisterOnTooltipShowTrigger = $attrs.$observe('tooltipShowTrigger', onTooltipShowTrigger)
           , unregisterOnTooltipHideTrigger = $attrs.$observe('tooltipHideTrigger', onTooltipHideTrigger)
+          , unregisterOnTooltipShowTooltip = $attrs.$observe('tooltipShowTooltip', onTooltipShowTooltip)
           , unregisterOnTooltipClassChange = $attrs.$observe('tooltipClass', onTooltipClassChange)
           , unregisterOnTooltipSmartChange = $attrs.$observe('tooltipSmart', onTooltipSmartChange)
           , unregisterOnTooltipCloseButtonChange = $attrs.$observe('tooltipCloseButton', onTooltipCloseButtonChange)
@@ -796,6 +813,7 @@
           unregisterOnTooltipSideChangeObserver();
           unregisterOnTooltipShowTrigger();
           unregisterOnTooltipHideTrigger();
+          unregisterOnTooltipShowTooltip();
           unregisterOnTooltipClassChange();
           unregisterOnTooltipSmartChange();
           unregisterOnTooltipCloseButtonChange();


### PR DESCRIPTION
This PR introduces the `tooltip-show-tooltip` attribute.

I'm not sure if this is a good use-case for everyone (or if there's already a way to do this functionality). This is just the solution we're using, but wondering if anyone else would find this helpful!

### Intro / Problem

We wanted to use an external tooltip library instead of our own for hovering on vertical bars on our bar graphs. However, we also wanted to display the tooltip on top of the bar if the user hovered over some empty area on top of the shorter bars. 

![image](https://cloud.githubusercontent.com/assets/2905198/26087832/516d7998-39c1-11e7-9f6e-e1c3bcfd6a66.png)


### Solution

Added the `tooltip-show-tooltip` attribute to the tooltips directive which accepts a bool. Then, set a `$scope` variable that controls whether or not the tooltip is displayed. On mouse enter on the empty area on top of shorter bars, we set that variable to `true` (and on mouse leave, `false`). This way, the area in which the tooltip is displayed is not limited to what's in the `<div tooltips>`.

```html
<div
  tooltips tooltip-template="i'm a tooltip"
  tooltip-show-tooltip="{{ isShow }}"
  tooltip-show-trigger="false"
  tooltip-hide-trigger="false"
>
  Toggle me by setting isShow
</div>
```

Here is a demo of using the `tooltip-show-tooltip` attribute on our app:

![img](https://d2ppvlu71ri8gs.cloudfront.net/items/1E3a353o0Z2E2H33441C/Screen%20Recording%202017-04-28%20at%2003.03%20PM.gif?v=71178e5e)

Towards the end, you can see that entering the empty area on top of the bar from the top triggers the tooltip.

### Example (plnkr)

http://plnkr.co/edit/oSKh6sGjDjP2yXxKLtPw?p=preview

### Thoughts

It's kind of messy how you have to do a `"false"` for both the show and hide trigger attributes, but please let me know your thoughts or comments! Especially if there's like a better way to do this with the existing functionality.