### PR TITLE
getTemplate() should always return a Promise

### DIFF
--- a/lib/angular-tooltips.js
+++ b/lib/angular-tooltips.js
@@ -269,7 +269,7 @@
       }
     };
   }
-  , tooltipDirective = /*@ngInject*/ ['$log', '$http', '$compile', '$timeout', '$controller', '$injector', 'tooltipsConf', '$templateCache', function tooltipDirective($log, $http, $compile, $timeout, $controller, $injector, tooltipsConf, $templateCache) {
+  , tooltipDirective = /*@ngInject*/ ['$log', '$http', '$compile', '$timeout', '$controller', '$injector', 'tooltipsConf', '$templateCache', '$q', function tooltipDirective($log, $http, $compile, $timeout, $controller, $injector, tooltipsConf, $templateCache, $q) {
 
     var linkingFunction = function linkingFunction($scope, $element, $attrs, $controllerDirective, $transcludeFunc) {
 
@@ -531,17 +531,17 @@
           
             var template = $templateCache.get(tooltipTemplateUrl);
 
-            if (typeof template === 'undefined') {
-              
-              // How should failing to load the template be handled?
-              template = $http.get(tooltipTemplateUrl).then(function onGetTemplateSuccess(response) {
-                
-                return response.data;
-              });
-              $templateCache.put(tooltipTemplateUrl, template);
+            if (typeof template !== 'undefined') {
+              // Wrap template in a Promise so that getTemplate always returns a Promise
+              return $q.resolve(template);
             }
-            
-            return template;
+
+            // How should failing to load the template be handled?
+            return $http.get(tooltipTemplateUrl).then(function onGetTemplateSuccess(response) {
+              $templateCache.put(tooltipTemplateUrl, response.data);
+
+              return response.data;
+            });
           }
           , onTooltipTemplateChange = function onTooltipTemplateChange(newValue) {
           


### PR DESCRIPTION
Fixes an issue where getTemplate() was expected to be a Promise but was actually a string.